### PR TITLE
sbt 0.13/1.0 crossbuild

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: scala
-scala:
-   - 2.10.5
+jdk: oraclejdk8
 script:
-  - "sbt ++$TRAVIS_SCALA_VERSION test"
-  - "sbt ++$TRAVIS_SCALA_VERSION scripted"
+  - "sbt ^^$SBT_VERSION test"
+  - "sbt ^^$SBT_VERSION scripted"
 branches:
   except:
     - /^v[0-9]/
@@ -11,4 +10,9 @@ cache:
   directories:
     - $HOME/.sbt
     - $HOME/.ivy2
-
+matrix:
+  include:
+    - env: SBT_VERSION="0.13.16"
+      scala: 2.10.7
+    - env: SBT_VERSION="1.0.4"
+      scala: 2.12.4

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,11 @@ name := "sbt-babel"
 
 description := "An SBT plugin to perform Babel compilation."
 
-scalaVersion := "2.10.6"
+sbtVersion in Global := "1.0.4"
+
+crossSbtVersions := Seq("1.0.4", "0.13.16")
+
+crossScalaVersions := Seq("2.12.4", "2.10.7")
 
 resolvers += Resolver.typesafeRepo("releases")
 

--- a/project/bintray.sbt
+++ b/project/bintray.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.2")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.0.4

--- a/project/scripted.sbt
+++ b/project/scripted.sbt
@@ -1,1 +1,1 @@
-libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value
+libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value

--- a/scripted.sbt
+++ b/scripted.sbt
@@ -1,3 +1,1 @@
-scriptedSettings
-
 scriptedLaunchOpts += ("-Dproject.version=" + version.value)


### PR DESCRIPTION
Switch to sbt 1.0 and crossbuild the plugin for both sbt 0.13 and 1.0.

For local testing i never got `+publishLocal` to work but
```
sbt:sbt-babel> ^^0.13.16
sbt:sbt-babel> publishLocal
```
and
```
sbt:sbt-babel> ^^1.0.4
sbt:sbt-babel> publishLocal
```

do work, so that's basically what the travis yaml does.